### PR TITLE
feat: support `formatOptions.date` to optionally hide date

### DIFF
--- a/src/reporters/basic.js
+++ b/src/reporters/basic.js
@@ -6,6 +6,7 @@ import { formatDate } from '../utils/date'
 const DEFAULTS = {
   dateFormat: 'HH:mm:ss',
   formatOptions: {
+    dateVisible: true,
     colors: false,
     compact: true
   }
@@ -39,9 +40,8 @@ export default class BasicReporter {
     }
   }
 
-  formatDate (date) {
-    const { dateFormat } = this.options
-    return dateFormat ? formatDate(dateFormat, date) : ''
+  formatDate(date) {
+    return this.options.formatOptions.dateVisible ? formatDate(this.options.dateFormat, date) : ''
   }
 
   filterAndJoin (arr) {

--- a/src/reporters/basic.js
+++ b/src/reporters/basic.js
@@ -40,7 +40,8 @@ export default class BasicReporter {
   }
 
   formatDate (date) {
-    return formatDate(this.options.dateFormat, date)
+    const { dateFormat } = this.options
+    return dateFormat ? formatDate(this.options.dateFormat, date) : ''
   }
 
   filterAndJoin (arr) {

--- a/src/reporters/basic.js
+++ b/src/reporters/basic.js
@@ -6,7 +6,7 @@ import { formatDate } from '../utils/date'
 const DEFAULTS = {
   dateFormat: 'HH:mm:ss',
   formatOptions: {
-    dateVisible: true,
+    date: true,
     colors: false,
     compact: true
   }
@@ -41,7 +41,7 @@ export default class BasicReporter {
   }
 
   formatDate(date) {
-    return this.options.formatOptions.dateVisible ? formatDate(this.options.dateFormat, date) : ''
+    return this.options.formatOptions.date ? formatDate(this.options.dateFormat, date) : ''
   }
 
   filterAndJoin (arr) {

--- a/src/reporters/basic.js
+++ b/src/reporters/basic.js
@@ -41,7 +41,7 @@ export default class BasicReporter {
 
   formatDate (date) {
     const { dateFormat } = this.options
-    return dateFormat ? formatDate(this.options.dateFormat, date) : ''
+    return dateFormat ? formatDate(dateFormat, date) : ''
   }
 
   filterAndJoin (arr) {

--- a/src/reporters/fancy.js
+++ b/src/reporters/fancy.js
@@ -9,6 +9,7 @@ import { TYPE_COLOR_MAP, LEVEL_COLOR_MAP } from '../utils/fancy'
 const DEFAULTS = {
   secondaryColor: 'grey',
   formatOptions: {
+    dateVisible: true,
     colors: true,
     compact: false
   }

--- a/src/reporters/fancy.js
+++ b/src/reporters/fancy.js
@@ -59,7 +59,8 @@ export default class FancyReporter extends BasicReporter {
 
     const secondaryColor = chalkColor(this.options.secondaryColor)
 
-    const date = secondaryColor(this.formatDate(logObj.date))
+    const date = this.formatDate(logObj.date)
+    const coloredDate = date && secondaryColor(date)
 
     const type = this.formatType(logObj, isBadge)
 
@@ -69,7 +70,7 @@ export default class FancyReporter extends BasicReporter {
 
     let line
     const left = this.filterAndJoin([type, formattedMessage])
-    const right = this.filterAndJoin([tag, date])
+    const right = this.filterAndJoin([tag, coloredDate])
     const space = width - stringWidth(left) - stringWidth(right) - 2
 
     if (space > 0 && width >= 80) {

--- a/src/reporters/fancy.js
+++ b/src/reporters/fancy.js
@@ -9,7 +9,7 @@ import { TYPE_COLOR_MAP, LEVEL_COLOR_MAP } from '../utils/fancy'
 const DEFAULTS = {
   secondaryColor: 'grey',
   formatOptions: {
-    dateVisible: true,
+    date: true,
     colors: true,
     compact: false
   }


### PR DESCRIPTION
If `formatOptions.date` is `false`, the date won't show. (Screenshot out of date)

<img width="1048" alt="image" src="https://user-images.githubusercontent.com/4312346/89125005-62716800-d52f-11ea-9bd8-8d6683ee4d37.png">

Defaults to `true` (same as current behavior).

<img width="1048" alt="image" src="https://user-images.githubusercontent.com/4312346/89125021-816ffa00-d52f-11ea-898e-7071ed73d9d5.png">

Closes https://cmty.app/nuxt/consola/issues/c75