### PR TITLE
chore: make example/index.js working

### DIFF
--- a/src/browser.js
+++ b/src/browser.js
@@ -1,6 +1,6 @@
 import Consola from './consola.js'
 import BrowserReporter from './reporters/browser.js'
-import { LogLevel } from './logLevels'
+import { LogLevel } from './logLevels.js'
 
 function createConsola () {
   const consola = new Consola({

--- a/src/types.js
+++ b/src/types.js
@@ -1,4 +1,4 @@
-import { LogLevel } from './logLevels'
+import { LogLevel } from './logLevels.js'
 
 export default {
   // Silent


### PR DESCRIPTION
Hey,

I wanted to test out consola quickly, cloned the repo and draw up an nginx. 

Initially the example `/examples/index.html` wasn't working as the file `logLevel` coulnd't be found (Accessing via browser console).
For me the fix was to add `.js` when importing the file.

I fixed the issue with this pr.